### PR TITLE
Bump faraday version in gemspec

### DIFF
--- a/synowebapi.gemspec
+++ b/synowebapi.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths   = ['lib']
 
   s.add_dependency 'httpclient'
-  s.add_dependency 'faraday', '~> 0'
-  s.add_dependency 'faraday_middleware', '~> 0'
+  s.add_dependency 'faraday'
+  s.add_dependency 'faraday_middleware'
 end


### PR DESCRIPTION
I want to use it together with another gem which depends on higher `faraday` version so need to bump it.
